### PR TITLE
リファクタリング: リクエスト一覧のコメント一覧をAjaxで取得するように変更

### DIFF
--- a/app/controllers/request_comments_controller.rb
+++ b/app/controllers/request_comments_controller.rb
@@ -1,6 +1,8 @@
 class RequestCommentsController < ApplicationController
   before_action :get_request
-  
+  def index
+    @request = Request.where(id: params[:request_id]).first
+  end
   def show
     @comments = @request.request_comments
     render :show_comments

--- a/app/views/lt_requests/index.html.erb
+++ b/app/views/lt_requests/index.html.erb
@@ -15,19 +15,10 @@
     <p>投稿日時:<%= request.created_at %> </p>
 
     <div class="btn-group">
-      <button type="button" id="request_comment<%= request.id%>" href="#" class="btn btn-danger btn-xs dropdown-toggle" data-toggle="dropdown" data-target="comment<%= request.id %>" >コメント一覧</button>
+      <button type="button" id="request_comment<%= request.id%>" style="display: none;" href="#" class="btn btn-danger btn-xs dropdown-toggle" data-toggle="dropdown" data-target="comment<%= request.id %>" >コメント一覧</button>
+      <%= link_to "コメント一覧", request_comments_index_path(request_id: request.id), remote: true, class: "btn btn-danger btn-xs dropdown-toggle" %>
       <div id="request_comments"></div>
       <div id="comment<%= request.id %>" class="dropdown-menu">
-        <% if request.request_comments.empty? %>
-          <p>コメントはありません</p>
-        <% else %>
-          <% request.request_comments.each do |request_comment| %>
-            <a><%= request_comment.member.account %></a>
-            <span><%= request_comment.created_at.strftime("%F"); %></span>
-            <div><%= request_comment.content %></div>
-            <div class="divider"></div>
-          <% end %>
-        <% end %>
       </div>
       <button data-toggle="modal" href="#requestCommentModal<%= request.id %>" class="btn btn-primary btn-xs"><%= glyph(:comment) %>&nbsp;コメントする</button>
       <%= render partial: 'comment/form', locals: { comment: request.request_comments.build } %>

--- a/app/views/request_comments/_list.html.erb
+++ b/app/views/request_comments/_list.html.erb
@@ -1,0 +1,10 @@
+  <% if request.request_comments.empty? %>
+    <p>コメントはありません</p>
+  <% else %>
+    <% request.request_comments.each do |request_comment| %>
+      <a><%= request_comment.member.account %></a>
+      <span><%= request_comment.created_at.strftime("%F"); %></span>
+      <div><%= request_comment.content %></div>
+      <div class="divider"></div>
+    <% end %>
+  <% end %>

--- a/app/views/request_comments/index.js.erb
+++ b/app/views/request_comments/index.js.erb
@@ -1,0 +1,2 @@
+$('#comment<%= @request.id %>').html("<%= escape_javascript(render partial: 'list', locals: { request: @request }) %>")
+$('#request_comment<%= @request.id %>').click()


### PR DESCRIPTION
コメント一覧の表示部分が、requests#indexのView中にあったので、request_comments#indexに対してAjax通信を利用して、コメントの情報を取得し、表示するように改善した。

この変更で、request_comments#indexがAjax通信用のアクションとなっているため、すべてのコメントの一覧の表示が必要になった場合に、使いたいアクションが使えない可能性がある。
 // ほぼ問題にはならないはず…

なお、requests#indexの表示は変更していない。
