### PR TITLE
fullcalender's version downgrade to 2.0.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,4 +62,5 @@ gem 'simple_form'
 gem "paranoia", "~> 2.0"
 
 #Use fullcalendar
-gem 'fullcalendar-rails'
+gem 'fullcalendar-rails', '~> 2.0.2.0'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,10 +81,7 @@ GEM
     debug_inspector (0.0.2)
     erubis (2.7.0)
     execjs (2.6.0)
-    fullcalendar-rails (2.4.0.2)
-      jquery-rails (>= 4.0.5, < 5.0.0)
-      jquery-ui-rails (>= 5.0.2)
-      momentjs-rails (>= 2.9.0)
+    fullcalendar-rails (2.0.2.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     hike (1.2.3)
@@ -96,8 +93,6 @@ GEM
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jquery-ui-rails (5.0.5)
-      railties (>= 3.2.16)
     json (1.8.3)
     kgio (2.10.0)
     less (2.6.0)
@@ -116,8 +111,6 @@ GEM
     mime-types (2.6.2)
     mini_portile (0.6.2)
     minitest (5.8.2)
-    momentjs-rails (2.10.6)
-      railties (>= 3.1)
     multi_json (1.11.2)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
@@ -214,7 +207,7 @@ DEPENDENCIES
   bootstrap-datepicker-rails!
   byebug
   coffee-rails (~> 4.0.0)
-  fullcalendar-rails
+  fullcalendar-rails (~> 2.0.2.0)
   jbuilder (~> 1.2)
   jquery-rails
   less-rails


### PR DESCRIPTION
fullcalenderの最新バージョン2.4.0.2で動かず、その他のバージョンも試したが、カレンダーが表示されなかったため、開発当時のバージョン2.0.2.0にダウングレード
