### PR TITLE
lightningtalk_paramsがcontent_pathの書換を許可していた問題の修正

### DIFF
--- a/app/controllers/lightningtalks_controller.rb
+++ b/app/controllers/lightningtalks_controller.rb
@@ -35,7 +35,6 @@ class LightningtalksController < ApplicationController
       :name,
       :member_id,
       :performance_date,
-      :content_path,
       :summary
     )
   end


### PR DESCRIPTION
ディレクトリトラバーサルの脆弱性を修正．
update時に不正なcontent_pathを送られることによって，任意のファイルへアクセス出来てしまう．
